### PR TITLE
Fixes for Windows

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -587,11 +587,13 @@ class AppEngineDeploy
         $bol_deploy = false;
         if(isset($this->arr_opt['f']) || isset($this->arr_opt['force'])) {
             $bol_deploy = true;
-        } else {
+        } elseif (function_exists('readline')) {
             $str_confirm = readline("Execute the deployment command? YOU SHOULD READ IT CAREFULLY (yes|no) : ");
             if('yes' == trim(strtolower($str_confirm))) {
                 $bol_deploy = true;
             }
+        } else {
+            $this->say('Cannot use `readline`. To deploy please re-run the command and pass a --force parameter.');
         }
         if(true === $bol_deploy) {
             passthru($str_cmd);

--- a/bin/deploy
+++ b/bin/deploy
@@ -587,13 +587,14 @@ class AppEngineDeploy
         $bol_deploy = false;
         if(isset($this->arr_opt['f']) || isset($this->arr_opt['force'])) {
             $bol_deploy = true;
-        } elseif (function_exists('readline')) {
+        } else {
+            if (!function_exists('readline')) {
+                throw new \InvalidArgumentException('Cannot use php `readline` function. To deploy please re-run the command but additionally pass a --force parameter.');
+            }
             $str_confirm = readline("Execute the deployment command? YOU SHOULD READ IT CAREFULLY (yes|no) : ");
             if('yes' == trim(strtolower($str_confirm))) {
                 $bol_deploy = true;
             }
-        } else {
-            $this->say('Cannot use `readline`. To deploy please re-run the command and pass a --force parameter.');
         }
         if(true === $bol_deploy) {
             passthru($str_cmd);

--- a/bin/deploy
+++ b/bin/deploy
@@ -588,7 +588,7 @@ class AppEngineDeploy
         if(isset($this->arr_opt['f']) || isset($this->arr_opt['force'])) {
             $bol_deploy = true;
         } else {
-            if (!function_exists('readline')) {
+            if(!function_exists('readline')) {
                 throw new \InvalidArgumentException('Cannot use php `readline` function. To deploy please re-run the command but additionally pass a --force parameter.');
             }
             $str_confirm = readline("Execute the deployment command? YOU SHOULD READ IT CAREFULLY (yes|no) : ");

--- a/bin/deploy
+++ b/bin/deploy
@@ -283,7 +283,7 @@ class AppEngineDeploy
      */
     private function getBaseDir()
     {
-        return $_SERVER['PWD'];
+        return getcwd();
     }
 
     /**


### PR DESCRIPTION
- Windows cannot use readline PHP function, instead it lets the user know that he can use the --force parameter
- Windows doesn't let you use $_SERVER['PWD'], so it was replaced with php's getcwd()
